### PR TITLE
feat: add fuzzy search to more accurately queue up tracks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     'plugin:react-hooks/recommended',
   ],
   rules: {
+    'no-continue': 'off',
     'react/jsx-filename-extension': 0,
     'import/extensions': 0,
     'prettier/prettier': [

--- a/src/service/spotify/SpotifyAPI.service.ts
+++ b/src/service/spotify/SpotifyAPI.service.ts
@@ -1,13 +1,9 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import axios, { AxiosResponse } from 'axios';
-import { fuzzy } from 'fast-fuzzy';
 import { SpotifyAuthentication } from '../../context/SpotifyAuthContext';
 import { WhoSampledData } from '../../types';
-import { TrackObjectFull } from '../../types/spotify-api';
+import findMatchingTrack from './utilities/utilities';
 
 export const BASE_URL = 'https://api.spotify.com/';
-const COMPARISON_THRESHOLD = 1.5;
-const EXACT_MATCH = 2;
 
 export const buildSpotifyHeaders = (
   spotifyAuth: SpotifyAuthentication,
@@ -66,29 +62,6 @@ export const findAndQueueTrack = async (
     const { error } = err;
     return `Unable to queue track, status: ${error.status}, message: ${error.message}`;
   }
-};
-
-const findMatchingTrack = (
-  items: TrackObjectFull[],
-  selectedTrack: WhoSampledData,
-): TrackObjectFull | undefined => {
-  let index = -1;
-  let compositeScore = -1;
-
-  for (let i = 0; i < items.length; i++) {
-    const { name, artists } = items[i];
-    // fuzzy does a 0-1 score
-    const trackMatch = fuzzy(name, selectedTrack.track_name);
-    const artistMatch = fuzzy(artists[0].name, selectedTrack.artist);
-    const tempCompositeScore = trackMatch + artistMatch;
-    if (tempCompositeScore > compositeScore) {
-      index = i;
-      compositeScore = tempCompositeScore;
-    }
-    if (compositeScore === EXACT_MATCH) break;
-  }
-
-  return compositeScore >= COMPARISON_THRESHOLD ? items[index] : undefined;
 };
 
 const generateSpotifyTrackAndArtistQueryURL = (

--- a/src/service/spotify/utilities/utilities.ts
+++ b/src/service/spotify/utilities/utilities.ts
@@ -1,0 +1,69 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { fuzzy } from 'fast-fuzzy';
+
+import { TrackObjectFull } from '../../../types/spotify-api';
+import { WhoSampledData } from '../../../types';
+
+const COMPARISON_THRESHOLD = 1.5;
+const COMPOSITE_EXACT_MATCH = 2;
+const EXACT_MATCH = 1;
+const MAX_WORD_DIFFERENCE = 2;
+const findMatchingTrack = (
+  items: TrackObjectFull[],
+  selectedTrack: WhoSampledData,
+): TrackObjectFull | undefined => {
+  const matchingTrack = items.find(
+    item =>
+      item.name === selectedTrack.track_name &&
+      item.artists[0].name === selectedTrack.artist,
+  );
+  if (matchingTrack) return matchingTrack;
+
+  return fuzzyFindMatchingTrack(items, selectedTrack);
+};
+
+const fuzzyFindMatchingTrack = (
+  items: TrackObjectFull[],
+  selectedTrack: WhoSampledData,
+) => {
+  let index = -1;
+  let compositeScore = -1;
+  for (let i = 0; i < items.length; i++) {
+    const { name, artists } = items[i];
+    // fuzzy does a 0-1 score
+    const trackMatch = fuzzy(name, selectedTrack.track_name);
+    const artistMatch = fuzzy(artists[0].name, selectedTrack.artist);
+    const tempCompositeScore = trackMatch + artistMatch;
+    console.log(trackMatch, artistMatch);
+    const trackExceedsSelectedTrackWordCount =
+      trackNameExceedsWordCountOfSelected(name, selectedTrack.track_name);
+
+    // since a string from spotify could contain the full substring of the track name
+    // we do a check to make sure that the word count difference between the spotify track name
+    // and the selected track name isn't too many words
+    if (trackMatch === EXACT_MATCH && trackExceedsSelectedTrackWordCount) {
+      continue;
+    }
+
+    if (tempCompositeScore > compositeScore) {
+      index = i;
+      compositeScore = tempCompositeScore;
+    }
+    if (compositeScore === COMPOSITE_EXACT_MATCH) break;
+  }
+
+  return compositeScore >= COMPARISON_THRESHOLD ? items[index] : undefined;
+};
+
+const trackNameExceedsWordCountOfSelected = (a: string, b: string): boolean => {
+  const aLength = a?.split(' ').length || 0;
+  const bLength = b?.split(' ').length || 0;
+  if (aLength > bLength) {
+    return aLength - bLength >= MAX_WORD_DIFFERENCE;
+  } else if (aLength < bLength) {
+    return true;
+  }
+  return false;
+};
+
+export default findMatchingTrack;


### PR DESCRIPTION
# Description
Added fuzzy matching on artist and track so we can more accurately queue up tracks if there's a slight variation in the text
Baked in a check to make sure that if the selected track is a substring of the track we're evaluating we skip it based on an exceeded word count (ie if we select 'Haunted' and a result is 'Haunted By My Ghosts' we don't consider that a full match).

Closes #35 